### PR TITLE
hotfix - Fix function name

### DIFF
--- a/src/hipay_professional/controllers/front/check.php
+++ b/src/hipay_professional/controllers/front/check.php
@@ -9,7 +9,7 @@
  * @license   https://github.com/hipay/hipay-wallet-sdk-prestashop/blob/master/LICENSE.md
  */
 
-class Hipay_ProfessionnalCheckModuleFrontController extends ModuleFrontController
+class Hipay_ProfessionalCheckModuleFrontController extends ModuleFrontController
 {
     public function postProcess()
     {


### PR DESCRIPTION
Error in function name. 
Fatal error Class 'hipay_professionalcheckModuleFrontController' not found.
Only one 'n' to professional